### PR TITLE
fix sm2.CryptSM2构造方法中使用public_key.lstrip(04)方法，会将公钥开头所有0 or 4开头的字符全部剔除

### DIFF
--- a/gmssl/sm2.py
+++ b/gmssl/sm2.py
@@ -22,7 +22,7 @@ class CryptSM2(object):
         mode: 0-C1C2C3, 1-C1C3C2 (default is 1)
         """
         self.private_key = private_key
-        self.public_key = public_key.lstrip("04") if public_key.startswith("04") else public_key
+        self.public_key = public_key[2:] if public_key.startswith("04") else public_key
         self.para_len = len(ecc_table['n'])
         self.ecc_a3 = (
             int(ecc_table['a'], base=16) + 3) % int(ecc_table['p'], base=16)


### PR DESCRIPTION
触发Odd-length string 异常

例如："0404axya9xxxx".lstrip("04") 实际输出为： "axya9xxxx" ，会导致公钥长度错误